### PR TITLE
update/ Vite and ESLint configuration: added new aliases

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,10 @@
 module.exports = {
   root: true,
-  env: { browser: true, es2020: true, node: true },
+  env: {
+    browser: true,
+    es2020: true,
+    node: true,
+  },
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
@@ -11,17 +15,27 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
     'prettier',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.js'],
   parserOptions: {
-    ecmaVersion: '2022',
+    ecmaVersion: 2022,
     sourceType: 'module',
-    ecmaFeatures: { jsx: true },
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   settings: {
-    react: { version: '18.2' },
+    react: {
+      version: 'detect',
+    },
     'import/resolver': {
-      vite: {
-        viteConfig: './vite.config.js',
+      alias: {
+        map: [
+          ['@', './src'],
+          ['components', './src/components'],
+          ['pages', './src/pages'],
+          ['assets', './src/assets'],
+        ],
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     },
   },

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -3,7 +3,7 @@ import {
   selectIsRefreshing,
   selectIsLoggedIn,
   selectUser,
-} from '../redux/auth/auth-selectors';
+} from '@/redux/auth/auth-selectors';
 
 export const useAuth = () => {
   const isLoggedIn = useSelector(selectIsLoggedIn);

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@vitejs/plugin-react": "^4.0.3",
         "eslint": "^8.45.0",
         "eslint-config-prettier": "^9.0.0",
-        "eslint-import-resolver-vite": "^2.1.0",
+        "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3277,6 +3277,19 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -3299,23 +3312,6 @@
       "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-vite": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-vite/-/eslint-import-resolver-vite-2.1.0.tgz",
-      "integrity": "sha512-n8JycJFvMqw4GeAPsl4JujpxBQzDrNpHYK1NK2aD1nsZJhNfH9WLhmuCPtafMj+RBxtXcXHgY5yDlQdJcXn5Ug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "resolve": "^1.22.8"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "eslint-plugin-import": "^2"
       }
     },
     "node_modules/eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@vitejs/plugin-react": "^4.0.3",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-import-resolver-vite": "^2.1.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,10 +8,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
-      src: '/src',
-      components: '/src/components',
-      pages: '/src/pages',
-      assets: '/src/assets',
+      components: fileURLToPath(new URL('./src/components', import.meta.url)),
+      pages: fileURLToPath(new URL('./src/pages', import.meta.url)),
+      assets: fileURLToPath(new URL('./src/assets', import.meta.url)),
     },
   },
   server: {


### PR DESCRIPTION
### Оновлення конфігурації Vite та ESLint

**Що було зроблено:**

1. Додано нові alias у `vite.config.js` для зручного імпорту.
2. Налаштовано ESLint `import/resolver` для коректної перевірки alias ('eslint-import-resolver-alias').

**Опис:**
1.  Тепер імпорти можна писати скорочено, без `../../`:

 ```
import authSelectors from '@/redux/auth/auth-selectors';
import Button from 'components/Button';
import sprite from 'assets/sprite.svg';
```

2. Для перевірки коректності імпортів та чистоти коду запусти: `npm run lint`   (також ESLint перевірить на наявність невикористаних змінних і console.log).

### Як додати новий alias:

1. В `vite.config.js`:
```
resolve: {
  alias: {
    utils: fileURLToPath(new URL('./src/utils', import.meta.url)),
  },
}
```

2. В `eslintrc.js`:
```
settings: {
  'import/resolver': {
    alias: {
      map: [['utils', './src/utils']],
      extensions: ['.js', '.jsx', '.ts', '.tsx'],
    },
  },
}
```

3.Перезапусти Vite 'npm run dev` або перезапуск VS Code, щоб зміни вступили в силу.


